### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,35 @@
+name: "Bump Version"
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  bump-version:
+    name: "Bump Version on master"
+    runs-on: ubuntu-latest
+
+  steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+        with:
+          ref: ${{ github.ref }}
+
+      - name: "cat package.json"
+        run: cat ./package.json
+
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@v1"
+        with:
+          node-version: 12
+
+      - name: "Automated Version Bump"
+        uses: "phips28/gh-action-bump-version@master"
+        with:
+          tag-prefix: ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "cat package.json"
+        run: cat ./package.json

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -10,7 +10,7 @@ jobs:
     name: "Bump Version on master"
     runs-on: ubuntu-latest
 
-  steps:
+    steps:
       - name: "Checkout source code"
         uses: "actions/checkout@v2"
         with:

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 10.0.0
+
+      - name: Change directory to package
+      run: cd package
+
+      - name: Install dependencies
+      run: yarn install
+
+      - name: Build
+      run: yarn build
+
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - if: steps.publish.type != 'none'
+      run: |
+        echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -9,28 +9,28 @@ jobs:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@master
+    - name: Checkout repository
+      uses: actions/checkout@master
 
-      - name: Set up Node.js
-        uses: actions/setup-node@master
-        with:
-          node-version: 10.0.0
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.0.0
 
-      - name: Change directory to package
-        run: cd package
+    - name: Change directory to package
+      run: cd package
 
-      - name: Install dependencies
-        run: yarn install
+    - name: Install dependencies
+      run: yarn install
 
-      - name: Build
-        run: yarn build
+    - name: Build
+      run: yarn build
 
-      - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+    - name: Publish to npm
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}
 
-      - if: steps.publish.type != 'none'
-        run: |
-          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"
+    - if: steps.publish.type != 'none'
+      run: |
+        echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -18,13 +18,13 @@ jobs:
           node-version: 10.0.0
 
       - name: Change directory to package
-      run: cd package
+        run: cd package
 
       - name: Install dependencies
-      run: yarn install
+        run: yarn install
 
       - name: Build
-      run: yarn build
+        run: yarn build
 
       - name: Publish to npm
         uses: JS-DevTools/npm-publish@v1
@@ -32,5 +32,5 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
 
       - if: steps.publish.type != 'none'
-      run: |
-        echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"
+        run: |
+          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"


### PR DESCRIPTION
This PR adds a github actions workflow to publish the package to NPM on every new release.

We would just need to worry about bumping the version and then creating a new release. The workflow will run the steps to make sure that the build is working as expected and publish it to NPM.