### PR TITLE
Update type of error parameter from getErrors and getErrorMessage

### DIFF
--- a/package/src/utils/getErrorMessage.ts
+++ b/package/src/utils/getErrorMessage.ts
@@ -1,3 +1,4 @@
+import { ApolloError } from '@apollo/client';
 import { ErrorResponse } from '@apollo/client/link/error';
 
 import getErrorsList from './getErrorsList';
@@ -7,7 +8,7 @@ import getErrorsList from './getErrorsList';
  * @param error The query error.
  */
 const getErrorMessage = (
-  error: ErrorResponse,
+  error: ErrorResponse | ApolloError,
 ) => {
   const errors = getErrorsList(error);
 

--- a/package/src/utils/getErrorsList.ts
+++ b/package/src/utils/getErrorsList.ts
@@ -1,11 +1,12 @@
 import { ErrorResponse } from '@apollo/client/link/error';
+import { ApolloError } from '@apollo/client';
 
 /**
  * Sanitizes a query error, returning a list of errors to be displayed.
  * @param error The query error.
  */
 const getErrorsList = (
-  error: ErrorResponse,
+  error: ErrorResponse | ApolloError,
 ) => {
   if (error?.networkError) {
     return ['Network Error'];


### PR DESCRIPTION
Now it's possible to pass an error from an apollo query to the ``getErrorsList`` and ``getErrorMessage`` functions 


Previous type error: 
![image](https://user-images.githubusercontent.com/48022589/90287058-7aa98700-de4d-11ea-90ff-6a7e3137d6eb.png)
